### PR TITLE
Using url.domainToASCII instead of punycode

### DIFF
--- a/lib/dnsUtils.js
+++ b/lib/dnsUtils.js
@@ -2,7 +2,7 @@
 
 const util = require('util')
 const packet = require('dns-packet')
-const punycode = require('punycode/') // "/" at end to avoid deprecated internal version
+const url = require('url')
 
 const CIRCULAR_MARK = Symbol('CIRCULAR_REFERENCE_MARK')
 
@@ -92,7 +92,7 @@ class DNSutils {
       name = undefined
     }
     opts = Object.assign({}, defaults, opts)
-    opts.name = punycode.toASCII(opts.name || name)
+    opts.name = url.domainToASCII(opts.name || name)
     opts.rrtype = (opts.rrtype || 'A').toUpperCase()
     return opts
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "dns-packet": "^5.2.1",
     "node-fetch": "^2.6.1",
     "nofilter": "^2.0.3",
-    "punycode": "^2.1.1",
     "yargs": "^17.0.1"
   },
   "devDependencies": {

--- a/test/dnsUtils.ava.js
+++ b/test/dnsUtils.ava.js
@@ -32,6 +32,12 @@ test('normalizeArgs', t => {
     name: 'xn--espaa-rta.icom.museum',
     rrtype: 'A'
   })
+  t.deepEqual(DNSutils.normalizeArgs('名がドメイン.com', undefined, {
+    rrtype: 'A'
+  }), {
+    name: 'xn--v8jxj3d1dzdz08w.com',
+    rrtype: 'A'
+  })
 })
 
 test('base64urlEncode', t => {


### PR DESCRIPTION
By using [url.domainToASCII](https://nodejs.org/docs/latest-v12.x/api/url.html#url_url_domaintoascii_domain) would reduce external dependency of **punycode**.