### PR TITLE
Support option to disable DNSSEC validation

### DIFF
--- a/pkg/dohdec-cli/README.md
+++ b/pkg/dohdec-cli/README.md
@@ -16,35 +16,37 @@ npm install -g dohdec-cli
 Usage: dohdec [options] [name] [rrtype]
 
 Arguments:
-  name                        DNS name to look up (e.g. domain name) or IP
-                              address to reverse lookup.  If not specified, a
-                              read-execute-print loop (REPL) is started.
-  rrtype                      Resource record name or number (default: "A")
+  name                          DNS name to look up (e.g. domain name) or IP
+                                address to reverse lookup.  If not specified, a
+                                read-execute-print loop (REPL) is started.
+  rrtype                        Resource record name or number (default: "A")
 
 Options:
-  -V, --version               output the version number
-  -c, --contentType <type>    MIME type for POST (default:
-                              "application/dns-message")
-  -d, --dns                   Use DNS format instead of JSON (ignored for TLS)
-  -s, --dnssec                Request DNSsec records
-  -k, --dnssec-cd             Disable DNSsec validation
-  -e, --ecs <number>          Use this many bits for EDNS Client Subnet (ECS)
-  -b, --ecsSubnet <address>   Use this IP address for EDNS Client Subnet (ECS)
-  -f, --full                  Full response, not just answers
-  -g, --get                   Force http GET for DNS-format lookups (default:
-                              true)
-  -n, --no-decode             Do not decode JSON or DNS wire format
-  -2, --no-http2              Disable http2 support
-  -t, --tls                   Use DNS-over-TLS instead of DNS-over-HTTPS
-  -i, --tlsServer <serverIP>  Connect to this DNS-over-TLS server (default:
-                              "1.1.1.1")
-  -p, --tlsPort <number>      Connect to this TCP port for DNS-over-TLS
-                              (default: 853)
-  -u, --url <URL>             The URL of the DoH service (default:
-                              "https://cloudflare-dns.com/dns-query")
-  -v, --verbose               Increase verbosity of debug information.  May be
-                              specified multiple times. (default: 0)
-  -h, --help                  display help for command
+  -V, --version                 output the version number
+  -c, --contentType <type>      MIME type for POST (default:
+                                "application/dns-message")
+  -d, --dns                     Use DNS format instead of JSON (ignored for
+                                TLS)
+  -s, --dnssec                  Request DNSsec records
+  -k, --dnssecCheckingDisabled  Disable DNSsec validation
+  -e, --ecs <number>            Use this many bits for EDNS Client Subnet (ECS)
+  -b, --ecsSubnet <address>     Use this IP address for EDNS Client Subnet
+                                (ECS)
+  -f, --full                    Full response, not just answers
+  -g, --get                     Force http GET for DNS-format lookups (default:
+                                true)
+  -n, --no-decode               Do not decode JSON or DNS wire format
+  -2, --no-http2                Disable http2 support
+  -t, --tls                     Use DNS-over-TLS instead of DNS-over-HTTPS
+  -i, --tlsServer <serverIP>    Connect to this DNS-over-TLS server (default:
+                                "1.1.1.1")
+  -p, --tlsPort <number>        Connect to this TCP port for DNS-over-TLS
+                                (default: 853)
+  -u, --url <URL>               The URL of the DoH service (default:
+                                "https://cloudflare-dns.com/dns-query")
+  -v, --verbose                 Increase verbosity of debug information.  May
+                                be specified multiple times.
+  -h, --help                    display help for command
 
 For more debug information:
 

--- a/pkg/dohdec-cli/README.md
+++ b/pkg/dohdec-cli/README.md
@@ -27,6 +27,7 @@ Options:
                               "application/dns-message")
   -d, --dns                   Use DNS format instead of JSON (ignored for TLS)
   -s, --dnssec                Request DNSsec records
+  -k, --dnssec-cd             Disable DNSsec validation
   -e, --ecs <number>          Use this many bits for EDNS Client Subnet (ECS)
   -b, --ecsSubnet <address>   Use this IP address for EDNS Client Subnet (ECS)
   -f, --full                  Full response, not just answers

--- a/pkg/dohdec-cli/lib/cli.js
+++ b/pkg/dohdec-cli/lib/cli.js
@@ -86,6 +86,7 @@ export class DnsCli extends Command {
       )
       .option('-d, --dns', 'Use DNS format instead of JSON (ignored for TLS)')
       .option('-s, --dnssec', 'Request DNSsec records')
+      .option('-k, --dnssec-cd', 'Disable DNSsec validation')
       .option(
         '-e, --ecs <number>',
         'Use this many bits for EDNS Client Subnet (ECS)',
@@ -180,6 +181,7 @@ For more debug information:
       ecsSubnet: this.argv.ecsSubnet,
       ecs: this.argv.ecs,
       dnssec: this.argv.dnssec,
+      dnssecCheckingDisabled: this.argv.dnssecCd,
     }
     try {
       if (net.isIP(opts.name)) {

--- a/pkg/dohdec-cli/lib/cli.js
+++ b/pkg/dohdec-cli/lib/cli.js
@@ -181,7 +181,7 @@ For more debug information:
       ecsSubnet: this.argv.ecsSubnet,
       ecs: this.argv.ecs,
       dnssec: this.argv.dnssec,
-      dnssecCheckingDisabled: this.argv.dnssecCd,
+      dnssecCheckingDisabled: this.argv.dnssecCheckingDisabled,
     }
     try {
       if (net.isIP(opts.name)) {

--- a/pkg/dohdec-cli/lib/cli.js
+++ b/pkg/dohdec-cli/lib/cli.js
@@ -86,7 +86,7 @@ export class DnsCli extends Command {
       )
       .option('-d, --dns', 'Use DNS format instead of JSON (ignored for TLS)')
       .option('-s, --dnssec', 'Request DNSsec records')
-      .option('-k, --dnssec-cd', 'Disable DNSsec validation')
+      .option('-k, --dnssecCheckingDisabled', 'Disable DNSsec validation')
       .option(
         '-e, --ecs <number>',
         'Use this many bits for EDNS Client Subnet (ECS)',

--- a/pkg/dohdec-cli/test/cli.ava.js
+++ b/pkg/dohdec-cli/test/cli.ava.js
@@ -24,6 +24,7 @@ Options:
                               "application/dns-message")
   -d, --dns                   Use DNS format instead of JSON (ignored for TLS)
   -s, --dnssec                Request DNSsec records
+  -k, --dnssec-cd             Disable DNSsec validation
   -e, --ecs <number>          Use this many bits for EDNS Client Subnet (ECS)
   -b, --ecsSubnet <address>   Use this IP address for EDNS Client Subnet (ECS)
   -f, --full                  Full response, not just answers

--- a/pkg/dohdec-cli/test/cli.ava.js
+++ b/pkg/dohdec-cli/test/cli.ava.js
@@ -13,35 +13,37 @@ const HELP = `\
 Usage: dohdec [options] [name] [rrtype]
 
 Arguments:
-  name                        DNS name to look up (e.g. domain name) or IP
-                              address to reverse lookup.  If not specified, a
-                              read-execute-print loop (REPL) is started.
-  rrtype                      Resource record name or number (default: "A")
+  name                          DNS name to look up (e.g. domain name) or IP
+                                address to reverse lookup.  If not specified, a
+                                read-execute-print loop (REPL) is started.
+  rrtype                        Resource record name or number (default: "A")
 
 Options:
-  -V, --version               output the version number
-  -c, --contentType <type>    MIME type for POST (default:
-                              "application/dns-message")
-  -d, --dns                   Use DNS format instead of JSON (ignored for TLS)
-  -s, --dnssec                Request DNSsec records
-  -k, --dnssec-cd             Disable DNSsec validation
-  -e, --ecs <number>          Use this many bits for EDNS Client Subnet (ECS)
-  -b, --ecsSubnet <address>   Use this IP address for EDNS Client Subnet (ECS)
-  -f, --full                  Full response, not just answers
-  -g, --get                   Force http GET for DNS-format lookups (default:
-                              true)
-  -n, --no-decode             Do not decode JSON or DNS wire format
-  -2, --no-http2              Disable http2 support
-  -t, --tls                   Use DNS-over-TLS instead of DNS-over-HTTPS
-  -i, --tlsServer <serverIP>  Connect to this DNS-over-TLS server (default:
-                              "1.1.1.1")
-  -p, --tlsPort <number>      Connect to this TCP port for DNS-over-TLS
-                              (default: 853)
-  -u, --url <URL>             The URL of the DoH service (default:
-                              "https://cloudflare-dns.com/dns-query")
-  -v, --verbose               Increase verbosity of debug information.  May be
-                              specified multiple times.
-  -h, --help                  display help for command
+  -V, --version                 output the version number
+  -c, --contentType <type>      MIME type for POST (default:
+                                "application/dns-message")
+  -d, --dns                     Use DNS format instead of JSON (ignored for
+                                TLS)
+  -s, --dnssec                  Request DNSsec records
+  -k, --dnssecCheckingDisabled  Disable DNSsec validation
+  -e, --ecs <number>            Use this many bits for EDNS Client Subnet (ECS)
+  -b, --ecsSubnet <address>     Use this IP address for EDNS Client Subnet
+                                (ECS)
+  -f, --full                    Full response, not just answers
+  -g, --get                     Force http GET for DNS-format lookups (default:
+                                true)
+  -n, --no-decode               Do not decode JSON or DNS wire format
+  -2, --no-http2                Disable http2 support
+  -t, --tls                     Use DNS-over-TLS instead of DNS-over-HTTPS
+  -i, --tlsServer <serverIP>    Connect to this DNS-over-TLS server (default:
+                                "1.1.1.1")
+  -p, --tlsPort <number>        Connect to this TCP port for DNS-over-TLS
+                                (default: 853)
+  -u, --url <URL>               The URL of the DoH service (default:
+                                "https://cloudflare-dns.com/dns-query")
+  -v, --verbose                 Increase verbosity of debug information.  May
+                                be specified multiple times.
+  -h, --help                    display help for command
 
 For more debug information:
 

--- a/pkg/dohdec/lib/dnsUtils.js
+++ b/pkg/dohdec/lib/dnsUtils.js
@@ -148,6 +148,7 @@ export class DNSutils extends EventEmitter {
    * @param {string} [opts.name] The name to look up.
    * @param {string} [opts.rrtype="A"] The record type to look up.
    * @param {boolean} [opts.dnssec=false] Request DNSSec information?
+   * @param {boolean} [opts.dnssecCd=false] Disable DNSSec validation?
    * @param {string} [opts.ecsSubnet] Subnet to use for ECS.
    * @param {number} [opts.ecs] Number of ECS bits.  Defaults to 24 or 56
    *   (IPv4/IPv6).
@@ -179,6 +180,9 @@ export class DNSutils extends EventEmitter {
       dns.flags |= packet.AUTHENTIC_DATA
       // @ts-ignore TS2339: types not up to date
       dns.additionals[0].flags |= packet.DNSSEC_OK
+      if (opts.dnssecCd) {
+        dns.flags |= packet.CHECKING_DISABLED
+      }
     }
     if (opts.ecs != null || net.isIP(opts.ecsSubnet) !== 0) {
       // https://tools.ietf.org/html/rfc7871#section-11.1

--- a/pkg/dohdec/lib/dnsUtils.js
+++ b/pkg/dohdec/lib/dnsUtils.js
@@ -148,7 +148,8 @@ export class DNSutils extends EventEmitter {
    * @param {string} [opts.name] The name to look up.
    * @param {string} [opts.rrtype="A"] The record type to look up.
    * @param {boolean} [opts.dnssec=false] Request DNSSec information?
-   * @param {boolean} [opts.dnssecCd=false] Disable DNSSec validation?
+   * @param {boolean} [opts.dnssecCheckingDisabled=false] Disable DNSSec
+   *   validation?
    * @param {string} [opts.ecsSubnet] Subnet to use for ECS.
    * @param {number} [opts.ecs] Number of ECS bits.  Defaults to 24 or 56
    *   (IPv4/IPv6).
@@ -180,7 +181,7 @@ export class DNSutils extends EventEmitter {
       dns.flags |= packet.AUTHENTIC_DATA
       // @ts-ignore TS2339: types not up to date
       dns.additionals[0].flags |= packet.DNSSEC_OK
-      if (opts.dnssecCd) {
+      if (opts.dnssecCheckingDisabled) {
         dns.flags |= packet.CHECKING_DISABLED
       }
     }

--- a/pkg/dohdec/lib/dnsUtils.js
+++ b/pkg/dohdec/lib/dnsUtils.js
@@ -181,9 +181,9 @@ export class DNSutils extends EventEmitter {
       dns.flags |= packet.AUTHENTIC_DATA
       // @ts-ignore TS2339: types not up to date
       dns.additionals[0].flags |= packet.DNSSEC_OK
-      if (opts.dnssecCheckingDisabled) {
-        dns.flags |= packet.CHECKING_DISABLED
-      }
+    }
+    if (opts.dnssecCheckingDisabled) {
+      dns.flags |= packet.CHECKING_DISABLED
     }
     if (opts.ecs != null || net.isIP(opts.ecsSubnet) !== 0) {
       // https://tools.ietf.org/html/rfc7871#section-11.1

--- a/pkg/dohdec/lib/doh.js
+++ b/pkg/dohdec/lib/doh.js
@@ -147,7 +147,8 @@ export class DNSoverHTTPS extends DNSutils {
    * @param {string} [opts.rrtype="A"] The record type to look up.
    * @param {boolean} [opts.decode=true] Parse the returned JSON?
    * @param {boolean} [opts.dnssec=false] Request DNSSEC records.
-   * @param {boolean} [opts.dnssecCd=false] Disable DNSSEC validation.
+   * @param {boolean} [opts.dnssecCheckingDisabled=false] Disable DNSSEC
+   *   validation.
    * @returns {Promise<string|object>} DNS result.
    */
   getJSON(opts) {
@@ -157,7 +158,7 @@ export class DNSoverHTTPS extends DNSutils {
     let req = `${this.opts.url}?name=${opts.name}&type=${rrtype}`
     if (opts.dnssec) {
       req += '&do=1'
-      if (opts.dnssecCd) {
+      if (opts.dnssecCheckingDisabled) {
         req += '&cd=1'
       }
     }
@@ -204,7 +205,7 @@ export class DNSoverHTTPS extends DNSutils {
       json: true,
       decode: true,
       dnssec: false,
-      dnssecCd: false,
+      dnssecCheckingDisabled: false,
     })
     this.verbose(1, 'DNSoverHTTPS.lookup options:', nopts)
 

--- a/pkg/dohdec/lib/doh.js
+++ b/pkg/dohdec/lib/doh.js
@@ -147,6 +147,7 @@ export class DNSoverHTTPS extends DNSutils {
    * @param {string} [opts.rrtype="A"] The record type to look up.
    * @param {boolean} [opts.decode=true] Parse the returned JSON?
    * @param {boolean} [opts.dnssec=false] Request DNSSEC records.
+   * @param {boolean} [opts.dnssecCd=false] Disable DNSSEC validation.
    * @returns {Promise<string|object>} DNS result.
    */
   getJSON(opts) {
@@ -156,6 +157,9 @@ export class DNSoverHTTPS extends DNSutils {
     let req = `${this.opts.url}?name=${opts.name}&type=${rrtype}`
     if (opts.dnssec) {
       req += '&do=1'
+      if (opts.dnssecCd) {
+        req += '&cd=1'
+      }
     }
     req += '&random_padding='
     req += cryptoRandomString({
@@ -200,6 +204,7 @@ export class DNSoverHTTPS extends DNSutils {
       json: true,
       decode: true,
       dnssec: false,
+      dnssecCd: false,
     })
     this.verbose(1, 'DNSoverHTTPS.lookup options:', nopts)
 

--- a/pkg/dohdec/lib/doh.js
+++ b/pkg/dohdec/lib/doh.js
@@ -158,9 +158,9 @@ export class DNSoverHTTPS extends DNSutils {
     let req = `${this.opts.url}?name=${opts.name}&type=${rrtype}`
     if (opts.dnssec) {
       req += '&do=1'
-      if (opts.dnssecCheckingDisabled) {
-        req += '&cd=1'
-      }
+    }
+    if (opts.dnssecCheckingDisabled) {
+      req += '&cd=1'
     }
     req += '&random_padding='
     req += cryptoRandomString({

--- a/pkg/dohdec/lib/dot.js
+++ b/pkg/dohdec/lib/dot.js
@@ -280,7 +280,7 @@ Received: "${hash}"`)
     const nopts = DNSutils.normalizeArgs(name, opts, {
       rrtype: 'A',
       dnsssec: false,
-      dnssecCd: false,
+      dnssecCheckingDisabled: false,
       decode: true,
       stream: true,
     })

--- a/pkg/dohdec/lib/dot.js
+++ b/pkg/dohdec/lib/dot.js
@@ -280,6 +280,7 @@ Received: "${hash}"`)
     const nopts = DNSutils.normalizeArgs(name, opts, {
       rrtype: 'A',
       dnsssec: false,
+      dnssecCd: false,
       decode: true,
       stream: true,
     })

--- a/pkg/dohdec/package.json
+++ b/pkg/dohdec/package.json
@@ -21,6 +21,7 @@
     "rfc8484"
   ],
   "author": "Joe Hildebrand <joe-github@cursive.net>",
+  "contributors": ["Gus Narea <gnarea@users.noreply.github.com>"],
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/pkg/dohdec/test/dnsUtils.ava.js
+++ b/pkg/dohdec/test/dnsUtils.ava.js
@@ -66,7 +66,7 @@ test('makePacket - dnssec', t => {
 })
 
 test('makePacket - dnssec with cd=1', t => {
-  const pkt = DNSutils.makePacket({name: 'foo', dnssec: true, dnssecCd: true})
+  const pkt = DNSutils.makePacket({name: 'foo', dnssec: true, dnssecCheckingDisabled: true})
   const dns = packet.decode(pkt)
   t.true(dns.flag_ad)
   t.true(dns.flag_cd)

--- a/pkg/dohdec/test/dnsUtils.ava.js
+++ b/pkg/dohdec/test/dnsUtils.ava.js
@@ -51,6 +51,27 @@ test('makePacket - subnet & ecs = 16', t => {
   t.is(options.sourcePrefixLength, ecs)
 })
 
+test('makePacket - dnssec disabled', t => {
+  const pkt = DNSutils.makePacket({name: 'foo'})
+  const dns = packet.decode(pkt)
+  t.false(dns.flag_ad)
+  t.false(dns.flag_cd)
+})
+
+test('makePacket - dnssec', t => {
+  const pkt = DNSutils.makePacket({name: 'foo', dnssec: true})
+  const dns = packet.decode(pkt)
+  t.true(dns.flag_ad)
+  t.false(dns.flag_cd)
+})
+
+test('makePacket - dnssec with cd=1', t => {
+  const pkt = DNSutils.makePacket({name: 'foo', dnssec: true, dnssecCd: true})
+  const dns = packet.decode(pkt)
+  t.true(dns.flag_ad)
+  t.true(dns.flag_cd)
+})
+
 test('normalizeArgs', t => {
   t.deepEqual(DNSutils.normalizeArgs('foo', 'mx'), {
     name: 'foo',

--- a/pkg/dohdec/test/doh.ava.js
+++ b/pkg/dohdec/test/doh.ava.js
@@ -90,7 +90,7 @@ test('DNSSEC with cd=1', async t => {
     verbose: 1,
     http2: false,
   })
-  const r = await doh.lookup('ietf.org', {rrtype: 'MX', dnssec: true, dnssecCd: true})
+  const r = await doh.lookup('ietf.org', {rrtype: 'MX', dnssec: true, dnssecCheckingDisabled: true})
   t.truthy(r)
   t.truthy(r.CD)
 })

--- a/pkg/dohdec/test/doh.ava.js
+++ b/pkg/dohdec/test/doh.ava.js
@@ -83,3 +83,14 @@ test('getJSON', async t => {
   const r = await doh.getJSON({name: 'ietf.org'})
   t.is(typeof r, 'object')
 })
+
+test('DNSSEC with cd=1', async t => {
+  const doh = new DNSoverHTTPS({
+    preferPost: false,
+    verbose: 1,
+    http2: false,
+  })
+  const r = await doh.lookup('ietf.org', {rrtype: 'MX', dnssec: true, dnssecCd: true})
+  t.truthy(r)
+  t.truthy(r.CD)
+})

--- a/pkg/dohdec/test/fixtures/doh.ava.js.json
+++ b/pkg/dohdec/test/fixtures/doh.ava.js.json
@@ -320,5 +320,59 @@
             "chunked"
         ],
         "responseIsBinary": false
+    },
+    {
+        "scope": "https://cloudflare-dns.com:443",
+        "method": "GET",
+        "path": "/dns-query?name=ietf.org&type=MX&random_padding=0&do=1&cd=1",
+        "body": "",
+        "status": 200,
+        "response": {
+            "Status": 0,
+            "TC": false,
+            "RD": true,
+            "RA": true,
+            "AD": true,
+            "CD": true,
+            "Question": [
+                {
+                    "name": "ietf.org",
+                    "type": 15
+                }
+            ],
+            "Answer": [
+                {
+                    "name": "ietf.org",
+                    "type": 15,
+                    "TTL": 1800,
+                    "data": "0 mail.ietf.org."
+                }
+            ]
+        },
+        "rawHeaders": [
+            "Date",
+            "Sun, 03 Oct 2021 17:16:31 GMT",
+            "Content-Type",
+            "application/dns-json",
+            "Content-Length",
+            "185",
+            "Connection",
+            "close",
+            "Report-To",
+            "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v3?s=NVBzzN6QkCMb4qGcHtGElr0IkiJ8%2FH3P5KM9AqDAM2B5VkvtguEFEZGkn%2FnMIGFcp7fLZIODNmf2rZ993hv4T4rXIegiyfkgNVHnq64s593L6uczZPhEtSjDZ8polFZ1cOueCQ%3D%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
+            "NEL",
+            "{\"report_to\":\"cf-nel\",\"max_age\":604800}",
+            "Access-Control-Allow-Origin",
+            "*",
+            "Expect-CT",
+            "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+            "Vary",
+            "Accept-Encoding",
+            "Server",
+            "cloudflare",
+            "CF-RAY",
+            "6987d1966bacc7b9-DEN"
+        ],
+        "responseIsBinary": false
     }
 ]

--- a/pkg/dohdec/types/dnsUtils.d.ts
+++ b/pkg/dohdec/types/dnsUtils.d.ts
@@ -8,6 +8,7 @@ export class DNSutils extends EventEmitter {
      * @param {string} [opts.name] The name to look up.
      * @param {string} [opts.rrtype="A"] The record type to look up.
      * @param {boolean} [opts.dnssec=false] Request DNSSec information?
+     * @param {boolean} [opts.dnssecCd=false] Disable DNSSec validation?
      * @param {string} [opts.ecsSubnet] Subnet to use for ECS.
      * @param {number} [opts.ecs] Number of ECS bits.  Defaults to 24 or 56
      *   (IPv4/IPv6).
@@ -21,6 +22,7 @@ export class DNSutils extends EventEmitter {
         name?: string;
         rrtype?: string;
         dnssec?: boolean;
+        dnssecCd?: boolean;
         ecsSubnet?: string;
         ecs?: number;
         stream?: boolean;

--- a/pkg/dohdec/types/dnsUtils.d.ts
+++ b/pkg/dohdec/types/dnsUtils.d.ts
@@ -8,7 +8,7 @@ export class DNSutils extends EventEmitter {
      * @param {string} [opts.name] The name to look up.
      * @param {string} [opts.rrtype="A"] The record type to look up.
      * @param {boolean} [opts.dnssec=false] Request DNSSec information?
-     * @param {boolean} [opts.dnssecCd=false] Disable DNSSec validation?
+     * @param {boolean} [opts.dnssecCheckingDisabled=false] Disable DNSSec validation?
      * @param {string} [opts.ecsSubnet] Subnet to use for ECS.
      * @param {number} [opts.ecs] Number of ECS bits.  Defaults to 24 or 56
      *   (IPv4/IPv6).
@@ -22,7 +22,7 @@ export class DNSutils extends EventEmitter {
         name?: string;
         rrtype?: string;
         dnssec?: boolean;
-        dnssecCd?: boolean;
+        dnssecCheckingDisabled?: boolean;
         ecsSubnet?: string;
         ecs?: number;
         stream?: boolean;

--- a/pkg/dohdec/types/doh.d.ts
+++ b/pkg/dohdec/types/doh.d.ts
@@ -77,7 +77,7 @@ export class DNSoverHTTPS extends DNSutils {
      * @param {string} [opts.rrtype="A"] The record type to look up.
      * @param {boolean} [opts.decode=true] Parse the returned JSON?
      * @param {boolean} [opts.dnssec=false] Request DNSSEC records.
-     * @param {boolean} [opts.dnssecCd=false] Disable DNSSEC validation.
+     * @param {boolean} [opts.dnssecCheckingDisabled=false] Disable DNSSEC validation.
      * @returns {Promise<string|object>} DNS result.
      */
     getJSON(opts: {
@@ -85,7 +85,7 @@ export class DNSoverHTTPS extends DNSutils {
         rrtype?: string;
         decode?: boolean;
         dnssec?: boolean;
-        dnssecCd?: boolean;
+        dnssecCheckingDisabled?: boolean;
     }): Promise<string | object>;
     /**
      * Look up a DNS entry using DNS-over-HTTPS (DoH).
@@ -141,7 +141,7 @@ export type DOH_LookupOptions = {
     /**
      * Disable DNSSec validation.
      */
-    dnssecCd?: boolean;
+    dnssecCheckingDisabled?: boolean;
     /**
      * What DoH endpoint should be
      * used?

--- a/pkg/dohdec/types/doh.d.ts
+++ b/pkg/dohdec/types/doh.d.ts
@@ -77,6 +77,7 @@ export class DNSoverHTTPS extends DNSutils {
      * @param {string} [opts.rrtype="A"] The record type to look up.
      * @param {boolean} [opts.decode=true] Parse the returned JSON?
      * @param {boolean} [opts.dnssec=false] Request DNSSEC records.
+     * @param {boolean} [opts.dnssecCd=false] Disable DNSSEC validation.
      * @returns {Promise<string|object>} DNS result.
      */
     getJSON(opts: {
@@ -84,6 +85,7 @@ export class DNSoverHTTPS extends DNSutils {
         rrtype?: string;
         decode?: boolean;
         dnssec?: boolean;
+        dnssecCd?: boolean;
     }): Promise<string | object>;
     /**
      * Look up a DNS entry using DNS-over-HTTPS (DoH).

--- a/pkg/dohdec/types/doh.d.ts
+++ b/pkg/dohdec/types/doh.d.ts
@@ -139,6 +139,10 @@ export type DOH_LookupOptions = {
      */
     dnssec?: boolean;
     /**
+     * Disable DNSSec validation.
+     */
+    dnssecCd?: boolean;
+    /**
      * What DoH endpoint should be
      * used?
      */

--- a/pkg/dohdec/types/dot.d.ts
+++ b/pkg/dohdec/types/dot.d.ts
@@ -167,7 +167,7 @@ export type DOT_LookupOptions = {
     /**
      * Disable DNSSec validation.
      */
-    dnssecCd?: boolean;
+    dnssecCheckingDisabled?: boolean;
 };
 export type pendingResolve = (results: Buffer | object) => any;
 export type pendingError = (error: Error) => any;

--- a/pkg/dohdec/types/dot.d.ts
+++ b/pkg/dohdec/types/dot.d.ts
@@ -160,10 +160,13 @@ export type DOT_LookupOptions = {
      */
     decode?: boolean;
     /**
-     * Request DNSSec records.  Currently
-     * requires `json: false`.
+     * Request DNSSec records.
      */
     dnssec?: boolean;
+    /**
+     * Disable DNSSec validation.
+     */
+    dnssecCd?: boolean;
 };
 export type pendingResolve = (results: Buffer | object) => any;
 export type pendingError = (error: Error) => any;

--- a/pkg/dohdec/types/dot.d.ts
+++ b/pkg/dohdec/types/dot.d.ts
@@ -160,7 +160,8 @@ export type DOT_LookupOptions = {
      */
     decode?: boolean;
     /**
-     * Request DNSSec records.
+     * Request DNSSec records.  Currently
+     * requires `json: false`.
      */
     dnssec?: boolean;
     /**


### PR DESCRIPTION
This enables the `cd` flag when DNSSEC records are requested, but we want to disable DNSSEC validation on the resolver.

I created this test file to test the changes against real resolvers (but didn't commit it):

```js
// pkg/dohdec/test/real.ava.js

import {DNSoverHTTPS} from '../lib/doh.js'
import {DNSoverTLS} from '../lib/index.js'
// eslint-disable-next-line node/no-missing-import
import test from 'ava'

test('DoH - no dnssec', async t => {
  const doh = new DNSoverHTTPS()
  const r = await doh.lookup('ietf.org', {
    json: false,
    dnssec: false,
  })
  t.truthy(r)

  t.false(r.answers.some(a => a.type === 'RRSIG'))
  t.false(r.flag_cd)
})

test('DoH - dnssec', async t => {
  const doh = new DNSoverHTTPS()
  const r = await doh.lookup('ietf.org', {
    json: false,
    dnssec: true,
  })
  t.truthy(r)

  t.true(r.answers.some(a => a.type === 'RRSIG'))
  t.false(r.flag_cd)
})

test('DoH - dnssec failed', async t => {
  const doh = new DNSoverHTTPS()
  const r = await doh.lookup('dnssec-failed.org', {
    json: false,
    dnssec: true,
  })
  t.truthy(r)

  t.is(r.rcode, 'SERVFAIL')
  t.is(r.answers.length, 0)
  t.false(r.flag_cd)
})

test('DoH - dnssec failed with cd=1', async t => {
  const doh = new DNSoverHTTPS()
  const r = await doh.lookup('dnssec-failed.org', {
    json: false,
    dnssec: true,
    dnssecCd: true,
  })
  t.truthy(r)

  t.is(r.rcode, 'NOERROR')
  t.true(r.answers.some(a => a.type === 'RRSIG'))
  t.true(r.flag_cd)
})

test('DoT - no dnssec', async t => {
  const dot = new DNSoverTLS()
  const r = await dot.lookup('ietf.org', {
    json: false,
    dnssec: false,
  })
  t.truthy(r)

  t.false(r.answers.some(a => a.type === 'RRSIG'))
  t.false(r.flag_cd)
})

test('DoT - dnssec', async t => {
  const dot = new DNSoverTLS()
  const r = await dot.lookup('ietf.org', {
    json: false,
    dnssec: true,
  })
  t.truthy(r)

  t.true(r.answers.some(a => a.type === 'RRSIG'))
  t.false(r.flag_cd)
})

test('DoT - dnssec failed', async t => {
  const dot = new DNSoverTLS()
  const r = await dot.lookup('dnssec-failed.org', {
    json: false,
    dnssec: true,
  })
  t.truthy(r)

  t.is(r.rcode, 'SERVFAIL')
  t.is(r.answers.length, 0)
  t.false(r.flag_cd)
})

```

Fixes #37