### PR TITLE
Refactor: do not await fetch trigger call

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "rfc8484"
   ],
   "author": "Joe Hildebrand <joe-github@cursive.net>",
+  "contributors": [
+    "SukkaW <oss@skk.moe> (https://skk.moe)"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pkg/dohdec/lib/agent.js
+++ b/pkg/dohdec/lib/agent.js
@@ -6,8 +6,7 @@ const UNDICI_GLOBAL_DISPATCHER = 'undici.globalDispatcher.1';
 const unidiciGlobalDispatcherSymbol = Symbol.for(UNDICI_GLOBAL_DISPATCHER);
 
 // Have to call fetch once to pre-load the undici Agent class.
-// eslint-disable-next-line n/no-top-level-await
-await fetch('').catch(() => {
+globalThis.fetch('').catch(() => {
   // Ignore.
 });
 


### PR DESCRIPTION
cc @hildjj 

We only need to access and invoke `fetch()` for Node.js to load the internal undici. We don't have to await the call.

This can be verified by running the following command in the terminal and examining the output:

```bash
$ node -e "console.log((globalThis)[Symbol.for('undici.globalDispatcher.1')])"
undefined

$ node -e "globalThis.fetch().catch(() => {}); console.log((globalThis)[Symbol.for('undici.globalDispatcher.1')])"
Agent {
  _events: [Object: null prototype] {},
  _eventsCount: 0,
  _maxListeners: undefined,
  Symbol(shapeMode): false,
  Symbol(kCapture): false,
  Symbol(nodejs.stream.destroyed): false,
  Symbol(onDestroyed): null,
  Symbol(closed): false,
  Symbol(onClosed): null,
  Symbol(options): { maxOrigins: Infinity, connect: undefined },
  Symbol(factory): [Function: defaultFactory],
  Symbol(clients): Map(0) {},
  Symbol(origins): Set(0) {},
  Symbol(onDrain): [Function (anonymous)],
  Symbol(onConnect): [Function (anonymous)],
  Symbol(onDisconnect): [Function (anonymous)],
  Symbol(onConnectionError): [Function (anonymous)]
}
```

Under the hood, Node.js implements lazy loading by defining `fetch` as a `getter` on the `globalThis`, thus the loading here is fully synchronous, no need to await.

All tests passed on my machine locally.